### PR TITLE
feat: Add Dockerfile templates for FastAPI, Flask, and Node

### DIFF
--- a/templates/node/Dockerfile.j2
+++ b/templates/node/Dockerfile.j2
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+EXPOSE {{ port }}
+
+ENV PORT={{ port }}
+
+CMD ["npm", "start"]

--- a/templates/python-fastapi/Dockerfile.j2
+++ b/templates/python-fastapi/Dockerfile.j2
@@ -1,0 +1,12 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE {{ port }}
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "{{ port }}"]

--- a/templates/python-flask/Dockerfile.j2
+++ b/templates/python-flask/Dockerfile.j2
@@ -1,0 +1,14 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE {{ port }}
+
+ENV PORT={{ port }}
+
+CMD ["python", "app.py"]


### PR DESCRIPTION
Added generic Dockerfile templates with Jinja2 placeholders for ports, consistent with the requirements in issue #1.